### PR TITLE
Added builder.reset functionality, allowing sequences to be restarted

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ factories.otherObject.build().email
 // => person_1@example.com
 ```
 
+Sometimes, a factory has a sequence that needs to be reset.  This is especially true in multiple-test situations where some sequences have cyclical data (like day of week).  This is easily achieved by running factory.reset()
+
+```javascript
+var factories = require('factories');
+factories.define('userWithMail', {
+  firstName: 'John',
+  lastName: 'Doe'
+})
+.sequence('email', function(i) {return 'person_' + i + '@example.com'});
+// sequence starts with i=0:
+factories.userWithMail.build().email
+// => person_0@example.com
+factories.userWithMail.reset();
+factories.userWithMail.build().email
+// => person_0@example.com
+
+```
+
 ## Traits
 
 You can use traits for advanced configuration:

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,6 +93,12 @@ Builder.prototype.create = function(count, callback) {
   }
 };
 
+Builder.prototype.reset = function() {
+  lodash.each(this.factory.sequences,function(sequence) {
+    sequence.counter=0;
+  });
+}
+
 var resolveDotNotation = function(name, value) {
   return name.split('.').reduceRight(function(object, key) {
     var o = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ Builder.prototype.reset = function() {
   lodash.each(this.factory.sequences,function(sequence) {
     sequence.counter=0;
   });
-}
+};
 
 var resolveDotNotation = function(name, value) {
   return name.split('.').reduceRight(function(object, key) {

--- a/test/factories.spec.js
+++ b/test/factories.spec.js
@@ -225,6 +225,25 @@ describe('Sequences', function() {
       .name.should.equal('Person_11');
   });
 
+  it('can be reset', function() {
+    factories
+      .define('withSequenceAndReset', {})
+      .sequence('name', function(i) {return 'Person_' + i;});
+    factories.withSequenceAndReset.build()
+      .name.should.equal('Person_0');
+    factories.withSequenceAndReset.build()
+      .name.should.equal('Person_1');
+    factories.withSequenceAndReset.build(10)[9]
+      .name.should.equal('Person_11');
+    factories.withSequenceAndReset.reset();
+    factories.withSequenceAndReset.build()
+      .name.should.equal('Person_0');
+    factories.withSequenceAndReset.build()
+      .name.should.equal('Person_1');
+    factories.withSequenceAndReset.build(10)[9]
+      .name.should.equal('Person_11');
+  });
+
   it('can be used for nested attributes using dot notation', function() {
     factories
       .define('withNestedSequence', {})
@@ -244,6 +263,19 @@ describe('Sequences', function() {
       .nameOfSequence.should.equal(0);
     factories.withGlobalSequence.build()
       .nameOfSequence.should.equal(1);
+  });
+  it('can reset globally', function () {
+    factories.sequence('nameOfSequence', function(i) {return i;});
+    factories
+      .define('withGlobalSequenceAndReset')
+      .sequence('nameOfSequence');
+    factories.withGlobalSequenceAndReset.build()
+      .nameOfSequence.should.equal(0);
+    factories.withGlobalSequenceAndReset.build()
+      .nameOfSequence.should.equal(1);
+    factories.withGlobalSequenceAndReset.reset();
+    factories.withGlobalSequenceAndReset.build()
+      .nameOfSequence.should.equal(0);
   });
 });
 


### PR DESCRIPTION
I added "factories.build" as an anonymous factory creation tool.  It allows the creation test-specific factories that have no chance of colliding with each other.
