### PR TITLE
Feature/lazy creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ factories.define('user', {
 });
 ```
 
+There is a special case with lazy attributes.  If .create() is called, and the lazy prototype includes an argument, that argument will be treated as a callback, and its asynchronous return value will populate the attribute instead.  This allows for asynchronous functions to be run within the building of the factory.
+
+```javascript
+factories.define('company', Company, {
+  // ...
+});
+factories.define('user', User, {
+  // ...
+  company: function(cb) { factories.Company.create(function(err,obj,created) { return cb && cb(created.id); } }
+});
+```
+
 ## Dependent Attributes
 
 When a factory is being built, the lazy attributes have access to the in-progress object using the variable 'this'.

--- a/README.md
+++ b/README.md
@@ -243,4 +243,4 @@ userFactory.afterCreate(function(object,createdObject,cb) {
 });
 ```
 
-A few notes about these hooks.  If you do not provide a value for object (or createdObject for create()) in the return or callback, the previous value will be reassigned to it.  If you do not run the callback in afterCreate, then create() will never respond with its callback.
+A few notes about these hooks.  If you do not provide a value for object (or createdObject for create()) in the return or callback, the previous value will be reassigned to it.  If you do not run the callback in afterCreate, then create() will never respond with its callback.  Finally, all assigned hooks will be run in the order they were added.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ factories.define('user', {
 });
 ```
 
+## Dependent Attributes
+
+When a factory is being built, the lazy attributes have access to the in-progress object using the variable 'this'.
+
+```javascript
+var factories = require('factories');
+factories.define('user', {
+  firstName: 'John',
+  lastName: 'Doe',
+  email: function() { return this.firstName + "." + this.lastName + "@example.com"; }
+});
+// build a user:
+factories.user.build();
+```
+
 ## Extending Attributes
 
 Sometimes, there is a need to create multiple similar objects from the same factory where those objects are otherwise too distinct or interrelated for sequences. In such a situation, it is useful (and a common pattern) to override some or all of the fields, while still maintaining the power of the factories (including support for sequences and traits).

--- a/README.md
+++ b/README.md
@@ -187,3 +187,60 @@ factories.user.build();
 // and an admin:
 factories.user.trait('admin').build();
 ```
+
+
+## After Hooks
+
+Sometimes, a factory just can't do everything you need, when you need it.  It cannot, for example, be used to automatically generate 1-to-many data against itself based upon the primary key.
+
+```javascript
+var factories = require('factories');
+factories.define('user', User, {
+  firstName: 'John',
+  lastName: 'Doe',
+  posts: function() {
+    var user_id = this.id; //note, this doesn't work!
+    factories.post.extend({id: user_id}).build(); //Which makes this impossible!
+  }
+});
+```
+
+The only correct solution, if you want to use the factory to build data like this, is to utilize after hooks.
+
+```javascript
+var factories = require('factories');
+factories.define('user', User, {
+  firstName: 'John',
+  lastName: 'Doe',
+}).afterCreate(function(object,createdObject,cb) {
+  var user_id = this.id; //note, this does work!
+  factories.post.extend({id: user_id}).build();
+  cb();
+});
+```
+
+The node-factories library supports 3 kinds of callback hooks. afterAttributes() adds a procedural hook after any build method has been called; afterBuild() adds a procedural hook after build() or create() (and it runs after the afterAttributes());  afterCalls adds an asynchronous hook after create() is called (and it runs after afterBuild() ).
+
+
+```javascript
+var factories = require('factories');
+var userFactory = factories.define('user', User, {
+  firstName: 'John',
+  lastName: 'Doe',
+});
+userFactory.afterAttributes(function(object) {
+  object.email = object.firstName + "." + object.lastName + "@example.com";
+  return object;
+});
+userFactory.afterBuild(function(object) {
+  object.id = 1; //This is not normally how you assign id, but it makes the afterCreate work in this contrived example.
+  return object;
+});
+userFactory.afterCreate(function(object,createdObject,cb) {
+  var user_id = this.id; //note, this does work!
+  factories.post.extend({id: user_id}).build();
+  cb();
+});
+```
+
+A few notes about these hooks.  If you do not provide a value for object (or createdObject for create()) in the return or callback, the previous value will be reassigned to it.  If you do not run the callback in afterCreate, then create() will never respond with its callback.

--- a/lib/index.js
+++ b/lib/index.js
@@ -118,9 +118,8 @@ Builder.prototype.create = function(count, callback) {
   };
   if (count) {
     async.map(this.build(count), create, function(err,data) {
-
-        var objects = lodash.map(data,function(row) { return row[0] });
-        var createdObjs = lodash.map(data,function(row) { return row[1] });
+        var objects = lodash.map(data,function(row) { return row[0]; });
+        var createdObjs = lodash.map(data,function(row) { return row[1]; });
         callback(err,objects,createdObjs);
     });
   } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,11 +29,10 @@ Builder = function(factory) {
 };
 
 var resolveFunctions = function(object,lazyArray) {
-  var setLazyValue = function(key,value,object,createdObj,cb) {
+  var setLazyValue = function(key,value,object,cb) {
       value.call(object,function(lazyVal) {
-          
           object[key] = lazyVal;
-          cb();
+          cb(null,object);
       });
   };
   for (var key in object) {
@@ -106,34 +105,47 @@ Builder.prototype.create = function(count, callback) {
   }
     self.modeLazy = 1;
     self.lazyMethods = [];
-  var create = function(object, cb) {
-    object.create(function(err,createdObj) {
-        if(self.lazyMethods.length) {
-            self.afterCreateCallbacks = self.lazyMethods.concat(self.afterCreateCallbacks);
-        }
-        if(self.afterCreateCallbacks.length) {
-            self.afterCreateCallbacks.unshift(function(cb) {
-                cb(null,object,createdObj);
-            });
-            var creationCallbacks = lodash.map(self.afterCreateCallbacks,function(innerCallback) {
-                return function(obj,createdObj,cb) {
-                    innerCallback(obj,createdObj,function(err,innerObj,innerCreatedObj) {
-                        innerObj = innerObj || obj;
-                        innerCreatedObj = innerCreatedObj || createdObj;
-                        cb(err,innerObj,innerCreatedObj);
-                    });
-                };
-            });
+    var create = function(object, cb) {
+    
+    var innerCreate = function(object, cb) {
+        object.create(function(err,createdObj) {
+            if(self.afterCreateCallbacks.length) {
+                self.afterCreateCallbacks.unshift(function(cb) {
+                    cb(null,object,createdObj);
+                });
+                var creationCallbacks = lodash.map(self.afterCreateCallbacks,function(innerCallback) {
+                    return function(obj,createdObj,cb) {
+                        innerCallback(obj,createdObj,function(err,innerObj,innerCreatedObj) {
+                            innerObj = innerObj || obj;
+                            innerCreatedObj = innerCreatedObj || createdObj;
+                            cb(err,innerObj,innerCreatedObj);
+                        });
+                    };
+                });
 
 
-            async.waterfall(creationCallbacks,function(err,object,createdObj) {
+                async.waterfall(creationCallbacks,function(err,object,createdObj) {
+                    cb(err, [object, createdObj]);
+                });
+            }
+            else {
                 cb(err, [object, createdObj]);
-            });
-        }
-        else {
-            cb(err, [object, createdObj]);
-        }
-    });
+            }
+        });
+    };
+
+    if(self.lazyMethods.length) {
+        var lazyCallbackMethods = [function(cb) {
+           cb(null,object);   
+        }].concat(self.lazyMethods);
+        async.waterfall(lazyCallbackMethods, function(err,object) {
+            innerCreate(object,cb);
+        });
+    }
+    else 
+    {
+        return innerCreate(object,cb);
+    }
   };
   if (count) {
     async.map(self.build(count), create, function(err,data) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,11 +28,23 @@ Builder = function(factory) {
   }
 };
 
-var resolveFunctions = function(object) {
+var resolveFunctions = function(object,lazyArray) {
+  var setLazyValue = function(key,value,object,createdObj,cb) {
+      value.call(object,function(lazyVal) {
+          
+          object[key] = lazyVal;
+          cb();
+      });
+  };
   for (var key in object) {
     var value = object[key];
     if (typeof value === 'function') {
-      object[key] = value.apply(object);
+      if(lazyArray && (value.length > 0)) {
+        lazyArray.push(setLazyValue.bind(null,key,value));
+      }
+      else {
+          object[key] = value.apply(object);
+      }
     } else if (typeof value === 'object') {
       resolveFunctions(object[key]);
     }
@@ -63,8 +75,8 @@ var objectOrArray = function(count, fn) {
 Builder.prototype.attributes = function(count) {
   var self = this;
   var attrSingle = function() {
-    var object = mergeChanges(self.factory.template, self.changes);
-    resolveFunctions(object);
+    var object = mergeChanges(self.factory.template, self.changes);    
+    resolveFunctions(object,self.modeLazy ? self.lazyMethods : null);
     lodash.each(self.afterAttributesCallbacks,function(callback) {
         object = callback.call(self,object) || object;
     });
@@ -92,8 +104,13 @@ Builder.prototype.create = function(count, callback) {
     callback = count;
     count = undefined;
   }
+    self.modeLazy = 1;
+    self.lazyMethods = [];
   var create = function(object, cb) {
     object.create(function(err,createdObj) {
+        if(self.lazyMethods.length) {
+            self.afterCreateCallbacks = self.lazyMethods.concat(self.afterCreateCallbacks);
+        }
         if(self.afterCreateCallbacks.length) {
             self.afterCreateCallbacks.unshift(function(cb) {
                 cb(null,object,createdObj);
@@ -107,6 +124,8 @@ Builder.prototype.create = function(count, callback) {
                     });
                 };
             });
+
+
             async.waterfall(creationCallbacks,function(err,object,createdObj) {
                 cb(err, [object, createdObj]);
             });
@@ -117,13 +136,13 @@ Builder.prototype.create = function(count, callback) {
     });
   };
   if (count) {
-    async.map(this.build(count), create, function(err,data) {
+    async.map(self.build(count), create, function(err,data) {
         var objects = lodash.map(data,function(row) { return row[0]; });
         var createdObjs = lodash.map(data,function(row) { return row[1]; });
         callback(err,objects,createdObjs);
     });
   } else {
-    create(this.build(), function(err,data) {
+    create(self.build(), function(err,data) {
         var objects = data[0];
         var createdObjs = data[1];
         callback(err,objects,createdObjs);

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ var resolveFunctions = function(object) {
   for (var key in object) {
     var value = object[key];
     if (typeof value === 'function') {
-      object[key] = value();
+      object[key] = value.apply(object);
     } else if (typeof value === 'object') {
       resolveFunctions(object[key]);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,18 +108,27 @@ Builder.prototype.create = function(count, callback) {
                 };
             });
             async.waterfall(creationCallbacks,function(err,object,createdObj) {
-                cb(err, object, createdObj);
+                cb(err, [object, createdObj]);
             });
         }
         else {
-            cb(err, object, createdObj);
+            cb(err, [object, createdObj]);
         }
     });
   };
   if (count) {
-    async.map(this.build(count), create, callback);
+    async.map(this.build(count), create, function(err,data) {
+
+        var objects = lodash.map(data,function(row) { return row[0] });
+        var createdObjs = lodash.map(data,function(row) { return row[1] });
+        callback(err,objects,createdObjs);
+    });
   } else {
-    create(this.build(), callback);
+    create(this.build(), function(err,data) {
+        var objects = data[0];
+        var createdObjs = data[1];
+        callback(err,objects,createdObjs);
+    });
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ Builder.prototype.reset = function() {
   lodash.each(this.factory.sequences,function(sequence) {
     sequence.counter=0;
   });
-}
+};
 
 var resolveDotNotation = function(name, value) {
   return name.split('.').reduceRight(function(object, key) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,10 @@ Builder = function(factory) {
   this.factory = factory;
   this.changes = [];
 
+  this.afterAttributesCallbacks = [];
+  this.afterBuildCallbacks = [];
+  this.afterCreateCallbacks = [];
+
   var sequenceWrapper = function(sequence) {
     return function() {
       return sequence.fn(sequence.counter++);
@@ -61,6 +65,9 @@ Builder.prototype.attributes = function(count) {
   var attrSingle = function() {
     var object = mergeChanges(self.factory.template, self.changes);
     resolveFunctions(object);
+    lodash.each(self.afterAttributesCallbacks,function(callback) {
+        object = callback.call(self,object) || object;
+    });
     return object;
   };
   return objectOrArray(count, attrSingle);
@@ -71,19 +78,42 @@ Builder.prototype.build = function(count) {
   var buildSingle = function() {
     var object = new self.factory.Constructor();
     lodash.assign(object, self.attributes());
+    lodash.each(self.afterBuildCallbacks,function(callback) {
+        object = callback.call(self,object) || object;
+    });
     return object;
   };
   return objectOrArray(count, buildSingle);
 };
 
 Builder.prototype.create = function(count, callback) {
+  var self = this;
   if (!callback) {
     callback = count;
     count = undefined;
   }
   var create = function(object, cb) {
-    object.create(function(err) {
-      cb(err, object);
+    object.create(function(err,createdObj) {
+        if(self.afterCreateCallbacks.length) {
+            self.afterCreateCallbacks.unshift(function(cb) {
+                cb(null,object,createdObj);
+            });
+            var creationCallbacks = lodash.map(self.afterCreateCallbacks,function(innerCallback) {
+                return function(obj,createdObj,cb) {
+                    innerCallback(obj,createdObj,function(err,innerObj,innerCreatedObj) {
+                        innerObj = innerObj || obj;
+                        innerCreatedObj = innerCreatedObj || createdObj;
+                        cb(err,innerObj,innerCreatedObj);
+                    });
+                };
+            });
+            async.waterfall(creationCallbacks,function(err,object,createdObj) {
+                cb(err, object, createdObj);
+            });
+        }
+        else {
+            cb(err, object, createdObj);
+        }
     });
   };
   if (count) {
@@ -120,6 +150,18 @@ Builder.prototype.trait = function(name) {
 Builder.prototype.extend = function(more) {
   this.changes.push(more);
   return this;
+};
+
+Builder.prototype.afterAttributes = function(cb) {
+    this.afterAttributesCallbacks.push(cb);
+};
+
+Builder.prototype.afterBuild = function(cb) {
+    this.afterBuildCallbacks.push(cb);
+};
+
+Builder.prototype.afterCreate = function(cb) {
+    this.afterCreateCallbacks.push(cb);
 };
 
 Factory = function(name, constructor, template) {

--- a/test/factories.spec.js
+++ b/test/factories.spec.js
@@ -268,26 +268,26 @@ describe('Extending objects', function() {
 
     it('extends an object, attributes unaltered', function() {
       var user = factories.userWithConstructor.attributes();
-      var extended_user = factories.userWithConstructor.extend({name: 'extended user name'}).attributes();
+      var extendedUser = factories.userWithConstructor.extend({name: 'extended user name'}).attributes();
       user.name.should.equal('user name');
-      extended_user.name.should.equal('extended user name');
+      extendedUser.name.should.equal('extended user name');
       user.should.not.be.instanceOf(User);
     });
 
     it('extends an array of objects using the constructor if a number is passed', function() {
       var users = factories.userWithConstructor.attributes(5);
-      var extended_users = factories.userWithConstructor.extend({name: 'extended user name'}).attributes(5);
+      var extendedUsers = factories.userWithConstructor.extend({name: 'extended user name'}).attributes(5);
       users.should.be.an.instanceOf(Array);
       users.length.should.equal(5);
       for (var i in users) {
         users[i].name.should.equal('user name');
         users[i].should.not.be.an.instanceOf(User);
       }
-      extended_users.should.be.an.instanceOf(Array);
-      extended_users.length.should.equal(5);
-      for (var i in extended_users) {
-        extended_users[i].name.should.equal('extended user name');
-        extended_users[i].should.not.be.an.instanceOf(User);
+      extendedUsers.should.be.an.instanceOf(Array);
+      extendedUsers.length.should.equal(5);
+      for (var j in extendedUsers) {
+        extendedUsers[j].name.should.equal('extended user name');
+        extendedUsers[j].should.not.be.an.instanceOf(User);
       }
     });
   });
@@ -296,29 +296,29 @@ describe('Extending objects', function() {
 
     it('creates an object using the given constructor', function() {
       var user = factories.userWithConstructor.build();
-      var extended_user = factories.userWithConstructor.extend({name: 'extended user name'}).build();
+      var extendedUser = factories.userWithConstructor.extend({name: 'extended user name'}).build();
       user.should.be.instanceOf(User);
       user.name.should.equal('user name');
-      extended_user.should.be.instanceOf(User);
-      extended_user.name.should.equal('extended user name');
+      extendedUser.should.be.instanceOf(User);
+      extendedUser.name.should.equal('extended user name');
       user.upperName().should.equal('USER NAME');
-      extended_user.upperName().should.equal('EXTENDED USER NAME');
+      extendedUser.upperName().should.equal('EXTENDED USER NAME');
     });
 
     it('creates an array of objects using the constructor if a number is passed', function() {
       var users = factories.userWithConstructor.build(5);
-      var extended_users = factories.userWithConstructor.extend({name: 'extended user name'}).build(5);
+      var extendedUsers = factories.userWithConstructor.extend({name: 'extended user name'}).build(5);
       users.should.be.an.instanceOf(Array);
       users.length.should.equal(5);
       for (var i in users) {
         users[i].name.should.equal('user name');
         users[i].should.be.an.instanceOf(User);
       }
-      extended_users.should.be.an.instanceOf(Array);
-      extended_users.length.should.equal(5);
-      for (var i in extended_users) {
-        extended_users[i].name.should.equal('extended user name');
-        extended_users[i].should.be.an.instanceOf(User);
+      extendedUsers.should.be.an.instanceOf(Array);
+      extendedUsers.length.should.equal(5);
+      for (var j in extendedUsers) {
+        extendedUsers[j].name.should.equal('extended user name');
+        extendedUsers[j].should.be.an.instanceOf(User);
       }
     });
   });
@@ -327,10 +327,10 @@ describe('Extending objects', function() {
     var count = 0;
     factories.define('extendWithFunction', {lazy: function() { count++; return count; }});
     count.should.equal(0);
-    var obj_extended = factories.extendWithFunction.extend({lazy: function() { return 42; } }).build();
-    var obj_extended2 = factories.extendWithFunction.extend({lazy: 84 }).build();
-    obj_extended.should.eql({lazy: 42});
-    obj_extended2.should.eql({lazy: 84});
+    var objExtended = factories.extendWithFunction.extend({lazy: function() { return 42; } }).build();
+    var objExtended2 = factories.extendWithFunction.extend({lazy: 84 }).build();
+    objExtended.should.eql({lazy: 42});
+    objExtended2.should.eql({lazy: 84});
     count.should.equal(0);
     var obj1 = factories.extendWithFunction.build();
     var obj2 = factories.extendWithFunction.build();

--- a/test/factories.spec.js
+++ b/test/factories.spec.js
@@ -394,4 +394,19 @@ describe('Extending objects', function() {
 
   });
 
+  describe('dependent factory behavior', function() {
+    var dependentFactory = factories.build({
+      first: 2,
+      second: 4,
+      sum: function() { return this.first+this.second; },
+      double: function() { return this.sum * 2; }
+    });
+    
+    var objDependent = dependentFactory.build();
+    objDependent.first.should.eql(2);
+    objDependent.second.should.eql(4);
+    objDependent.sum.should.eql(6);
+    objDependent.double.should.eql(12);
+  });
+
 });

--- a/test/factories.spec.js
+++ b/test/factories.spec.js
@@ -7,7 +7,9 @@ User.prototype.upperName = function() { return this.name.toUpperCase(); };
 User.prototype.create = function(cb) {
     var self = this;
   process.nextTick(function() {
-    cb(null,{ name: self.name,built: 1 });
+    var newUser = self;
+    newUser.built = 1;
+    cb(null,newUser);
   });
 };
 
@@ -317,23 +319,19 @@ describe('References to other factories', function() {
 
 describe('Lazy creation', function() {
     it('allows attributes to be set lazily when .create() is used',function(done) {
-        var Lazy = function() {};
-        Lazy.prototype.create = function(cb) {
-          process.nextTick(function() { cb(null,{a: 1,b: 2}) });
-        };
 
-        factories.define('LazyTest',Lazy,{
-            c: function() { return 3; },
-            //d: function(cb) { return cb && cb(4); },
+        factories.define('LazyTest',User,{
+            a: 3,
+            b: function() { return 4; },
+            c: function(cb) { return cb && cb(5); },
         });
 
         factories.LazyTest.create(function(err,obj,created) {
-            created.a.should.eql(1);
-            created.b.should.eql(2);
-            console.dir(obj);
-            console.dir(created);
-//            created.c.should.eql(3);
-//            created.d.should.eql(4);
+            created.a.should.eql(3);
+            created.b.should.eql(4);
+            created.c.should.eql(5);
+            created.built.should.eql(1);
+            done();
         });
 
     });
@@ -344,7 +342,6 @@ describe('Inheritance of factories', function() {
 });
 
 describe('Extending objects', function() {
-  
   describe('attributes(count)', function() {
 
     it('extends an object, attributes unaltered', function() {
@@ -438,6 +435,7 @@ describe('Extending objects', function() {
 
   describe('after hooks', function() {
     describe('afterAttributes', function() {
+        
         var afterAttributesFactoryRan = 0;
         var afterAttributesFactory = factories.build({
             x: function() { return 6*7; }

--- a/test/factories.spec.js
+++ b/test/factories.spec.js
@@ -315,6 +315,30 @@ describe('References to other factories', function() {
   });
 });
 
+describe('Lazy creation', function() {
+    it('allows attributes to be set lazily when .create() is used',function(done) {
+        var Lazy = function() {};
+        Lazy.prototype.create = function(cb) {
+          process.nextTick(function() { cb(null,{a: 1,b: 2}) });
+        };
+
+        factories.define('LazyTest',Lazy,{
+            c: function() { return 3; },
+            //d: function(cb) { return cb && cb(4); },
+        });
+
+        factories.LazyTest.create(function(err,obj,created) {
+            created.a.should.eql(1);
+            created.b.should.eql(2);
+            console.dir(obj);
+            console.dir(created);
+//            created.c.should.eql(3);
+//            created.d.should.eql(4);
+        });
+
+    });
+});
+
 describe('Inheritance of factories', function() {
 
 });

--- a/test/factories.spec.js
+++ b/test/factories.spec.js
@@ -146,22 +146,22 @@ describe('Building objects', function() {
   });
 
   describe('anonymous Factories.build no constructor', function() {
-      var user_factory = factories.build({name: 'anonymous factory user'});
-      var user = user_factory.attributes();
+      var userFactory = factories.build({name: 'anonymous factory user'});
+      var user = userFactory.attributes();
       user.should.not.be.instanceOf(User);
       user.name.should.equal('anonymous factory user');
   });
 
   describe('anonymous Factories.build attributes', function() {
-      var user_factory = factories.build(User,{name: 'anonymous factory user'});
-      var user = user_factory.attributes();
+      var userFactory = factories.build(User,{name: 'anonymous factory user'});
+      var user = userFactory.attributes();
       user.should.not.be.instanceOf(User);
       user.name.should.equal('anonymous factory user');
   });
 
   describe('anonymous Factories.build', function() {
-      var user_factory = factories.build(User,{name: 'anonymous factory user'});
-      var user = user_factory.build();
+      var userFactory = factories.build(User,{name: 'anonymous factory user'});
+      var user = userFactory.build();
       user.should.be.instanceOf(User);
       user.name.should.equal('anonymous factory user');
       user.upperName().should.equal('ANONYMOUS FACTORY USER');


### PR DESCRIPTION
This pull request unfortunately needs to include the pulls from previous features to work.

I've modified the lazy attributes so that when create() is called, they can optionally run in async mode.  This allows the create() of another object and return of its generated id, or similar behavior.
